### PR TITLE
Add php_htmlInStrings=2 to fix highlighting of $start='<?php';

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -17,3 +17,8 @@ optional features such as `php_alt_comparison`
 Some color schemes such as `elflord` use the same highlighting for known classes (e.g. RuntimeError) as unknown class names.
 
 To see the effect of changing a vim setting such as `php_alt_comparisons` without reloading vim, the command `:do Syntax` can be used.
+
+Showing errors
+--------------
+
+`:messages` shows the error and the error line

--- a/README.md
+++ b/README.md
@@ -16,3 +16,65 @@ In neovim, [syntax/php.vim](syntax/php.vim) can be placed in `~/.config/nvim/syn
 (`~/AppData/Local/nvim/syntax/php.vim` on Windows)
 
 Alternately, php vim syntax files can be installed and updated using a plugin manager such as [vim-plug](https://github.com/junegunn/vim-plug), [vundle](https://github.com/VundleVim/Vundle.vim), or [pathogen.vim](https://github.com/tpope/vim-pathogen) by using this repo as a plugin ([TysonAndre/php-vim-syntax](https://github.com/TysonAndre/php-vim-syntax) from github).
+
+Documentation
+-------------
+
+See `:help ft-php-syntax` and [`syntax/php.vim`](syntax/php.vim)
+
+
+```
+Note: If you are using a colour terminal with dark background, you will
+      probably find the 'elflord' colorscheme is much better for PHP's syntax
+      than the default colourscheme, because elflord's colours will better
+      highlight the break-points (Statements) in your code.
+
+Options:
+  Set to anything to enable:
+    php_sql_query           SQL syntax highlighting inside strings
+    php_htmlInStrings       HTML syntax highlighting inside strings
+
+                            By setting this to 2 instead, this will use a local copy of
+                            HTML syntax highlighting instead of the official
+                            HTML syntax highlighting, and properly highlight
+                            `<?php $startTag = '<?php';`.
+                            This may become the new default in the future.
+
+                            By setting this to 3, this will use the
+                            official installed top level html syntax highlighting rules.
+    php_baselib             highlighting baselib functions
+    php_asp_tags            highlighting ASP-style short tags
+    php_parent_error_close  highlighting parent error ] or )
+    php_parent_error_open   skipping an php end tag, if there exists
+                              an open ( or [ without a closing one
+    php_oldStyle            use old colorstyle
+    php_noShortTags         don't sync <? ?> as php
+  Set to a specific value:
+    php_folding = 1         fold classes and functions
+    php_folding = 2         fold all { } regions
+    php_sync_method = x  where x is an integer:
+                      -1  sync by search ( default )
+                      >0  sync at least x lines backwards
+                      0   sync from start
+  Set to 0 to _disable_:      (Added by Peter Hodge On June 9, 2006)
+    php_special_functions = 0      highlight functions with abnormal behaviour
+    php_alt_comparisons = 0        comparison operators in an alternate colour
+    php_alt_assignByReference = 0  '= &' in an alternate colour
+
+
+Note:
+Setting php_folding=1 will match a closing } by comparing the indent
+before the class or function keyword with the indent of a matching }.
+Setting php_folding=2 will match all of pairs of {,} ( see known
+bugs ii )
+
+Known Bugs:
+ - setting  php_parent_error_close  on  and  php_parent_error_open  off
+   has these two leaks:
+    i) A closing ) or ] inside a string match to the last open ( or [
+       before the string, when the the closing ) or ] is on the same line
+       where the string started. In this case a following ) or ] after
+       the string would be highlighted as an error, what is incorrect.
+   ii) Same problem if you are setting php_folding = 2 with a closing
+       } inside an string on the first line of this string.
+```

--- a/examples/embedding.php
+++ b/examples/embedding.php
@@ -1,0 +1,20 @@
+<h1>test</h1>
+
+<img onload="alert(1)"></div>
+<style>
+color: blue;
+</style>
+<?php
+// test of php_sql_query (SQL syntax highlighting inside strings)
+$sql = 'SELECT name FROM users WHERE id = 123;';
+// test of php-htmlInStrings error highlighting
+$scriptErrorTag = "<a> << ";
+$script = 'script to set window.x to 123;<script>window.x = 123; alert(1);</script>';
+$img = '<img width="800" height="600" onload="window.afterLoaded(1);" src="/test.png" />';
+$style = '<style>color: blue;</style>';
+// Note that by default, setting php_htmlInStrings will have an issue with '<?php';
+// (because this is using the html syntax rules inside of quoted php strings,
+// and syntax/php.vim also extends the exact same html syntax rules to allow embedding php)
+$phpTagName = '<?php';
+$other = 123;
+// With php_htmlInStrings=2 (copying a subset of the html rules), this comment should show up as an ordinary comment, not a string ';

--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: php PHP 3/4/5/7/8
 " Maintainer: Tyson Andre <tysonandre775@hotmail.com>
-" Last Change: Apr 21, 2021
+" Last Change: May 22, 2021
 " URL: https://github.com/TysonAndre/php-vim-syntax
 " Former Maintainers: 
 "         Jason Woofenden <jason@jasonwoof.com>
@@ -13,10 +13,33 @@
 "       than the default colourscheme, because elflord's colours will better
 "       highlight the break-points (Statements) in your code.
 "
+" Note: This embeds a modified copy of the html.vim with (mostly) different symbols,
+" in order to implement php_htmlInStrings=2 can work as expected and correctly parse
+" `<?php $phpStartTag = '<?php';`.
+"
+" Credits for the original version of html.vim prior to modifications
+" https://github.com/vim/vim/blob/master/runtime/syntax/html.vim 
+"
+"   Previous Maintainer Jorge Maldonado Ventura <jorgesumle@freakspot.net>
+"   Previous Maintainer Claudio Fleiner <claudio@fleiner.com>
+"   Repository          https://notabug.org/jorgesumle/vim-html-syntax
+"   Last Change         2021 Mar 02
+"			Included patch #7900 to fix comments
+"			Included patch #7916 to fix a few more things
+"
 " Options:
 "   Set to anything to enable:
 "     php_sql_query           SQL syntax highlighting inside strings
 "     php_htmlInStrings       HTML syntax highlighting inside strings
+" 
+"                             By setting this to 2, this will use a local copy of
+"                             HTML syntax highlighting instead of the official
+"                             HTML syntax highlighting, and properly highlight
+"                             `<?php $startTag = '<?php';`.
+"                             This may become the new default in the future.
+" 
+"                             By setting this to 3 (or any unrecognized value), 
+"                             this will use the official installed top level html syntax highlighting rules.
 "     php_baselib             highlighting baselib functions
 "     php_asp_tags            highlighting ASP-style short tags
 "     php_parent_error_close  highlighting parent error ] or )
@@ -62,6 +85,215 @@ if !exists("main_syntax")
   let main_syntax = 'php'
 endif
 
+" Start of copy of html for embedding in strings with  {{{
+" This is a clone of
+" https://github.com/vim/vim/blob/master/runtime/syntax/html.vim
+" from 2021 Mar 02 with changed symbols and modifications to rules. See the Note in the file header.
+"
+" The default behavior of php_htmlInStrings causes a bug
+" when you're working with code that contains the string literal `'<?php'`.
+" E.g. code that reads php files or generates the contents of php files or 
+" generates snippets to `eval()`.
+" 
+" When php_htmlInStrings was set to any value,
+" it would cause the html syntax rules to be embedded inside of the string
+" contents.
+" 
+" However, php.vim extends html.vim by allowing the php start tag to be
+" included, meaning that this is parsed as `<?php';`, i.e. the start of a
+" new string literal.
+" 
+" Work around that by using a different set of rules that don't allow
+" embedding php in most places (phpInnerHtmlPreProc).
+" 
+" The default behavior may be changed to this in the future for constants other
+" than 2 or 3 if there are no issues.
+"
+" Many, but not all syntax rules were changed from html* to phpInnerHtml*
+if exists("php_htmlInStrings") && php_htmlInStrings==2
+  " mark illegal characters
+  syn match phpInnerHtmlError contained "[<>&]"
+
+  " tags
+  syn region  phpInnerHtmlString   contained start=+"+ end=+"+ contains=phpInnerHtmlSpecialChar,javaScriptExpression,@phpInnerHtmlPreproc
+  syn region  phpInnerHtmlString   contained start=+'+ end=+'+ contains=phpInnerHtmlSpecialChar,javaScriptExpression,@phpInnerHtmlPreproc
+  syn match   phpInnerHtmlValue    contained "=[\t ]*[^'" \t>][^ \t>]*"hs=s+1   contains=javaScriptExpression,@phpInnerHtmlPreproc
+  syn region  phpInnerHtmlEndTag   contained start=+</+      end=+>+ contains=phpInnerHtmlTagN,phpInnerHtmlTagError
+  syn region  phpInnerHtmlTag      contained start=+<[^/]+   end=+>+ fold contains=phpInnerHtmlTagN,phpInnerHtmlString,htmlArg,phpInnerHtmlValue,phpInnerHtmlTagError,phpInnerHtmlEvent,phpInnerHtmlCssDefinition,@phpInnerHtmlPreproc,@phpInnerHtmlArgCluster
+  syn match   phpInnerHtmlTagN     contained +<\s*[-a-zA-Z0-9]\++hs=s+1 contains=htmlTagName,htmlSpecialTagName,@phpInnerHtmlTagNameCluster
+  syn match   phpInnerHtmlTagN     contained +</\s*[-a-zA-Z0-9]\++hs=s+2 contains=htmlTagName,htmlSpecialTagName,@phpInnerHtmlTagNameCluster
+  syn match   phpInnerHtmlTagError contained "[^>]<"ms=s+1
+
+
+  " special characters
+  syn match phpInnerHtmlSpecialChar "&#\=[0-9A-Za-z]\{1,8};"
+
+  " Comments (the real ones or the old netscape ones)
+  if exists("html_wrong_comments")
+    syn region phpInnerHtmlComment        start=+<!--+    end=+--\s*>+    contains=@Spell
+  else
+    " The HTML 5.2 syntax 8.2.4.41: bogus comment is parser error; browser skips until next &gt
+    syn region phpInnerHtmlComment        start=+<!+      end=+>+         contains=phpInnerHtmlCommentError keepend
+    " Idem 8.2.4.42,51: Comment starts with <!-- and ends with -->
+    " Idem 8.2.4.43,44: Except <!--> and <!---> are parser errors
+    " Idem 8.2.4.52: dash-dash-bang (--!>) is error ignored by parser, also closes comment
+    syn region phpInnerHtmlComment matchgroup=phpInnerHtmlComment start=+<!--\%(-\?>\)\@!+        end=+--!\?>+    contains=phpInnerHtmlCommentNested,@phpInnerHtmlPreProc,@Spell keepend
+    " Idem 8.2.4.49: nested comment is parser error, except <!--> is all right
+    syn match phpInnerHtmlCommentNested contained "<!-->\@!"
+    syn match phpInnerHtmlCommentError  contained "[^><!]"
+  endif
+  syn region phpInnerHtmlComment  start=+<!DOCTYPE+       end=+>+ keepend
+
+  " server-parsed commands
+  syn region phpInnerHtmlPreProc start=+<!--#+ end=+-->+ contains=phpInnerHtmlPreStmt,phpInnerHtmlPreError,phpInnerHtmlPreAttr
+  syn match phpInnerHtmlPreStmt contained "<!--#\(config\|echo\|exec\|fsize\|flastmod\|include\|printenv\|set\|if\|elif\|else\|endif\|geoguide\)\>"
+  syn match phpInnerHtmlPreError contained "<!--#\S*"ms=s+4
+  syn match phpInnerHtmlPreAttr contained "\w\+=[^"]\S\+" contains=phpInnerHtmlPreProcAttrError,phpInnerHtmlPreProcAttrName
+  syn region phpInnerHtmlPreAttr contained start=+\w\+="+ skip=+\\\\\|\\"+ end=+"+ contains=phpInnerHtmlPreProcAttrName keepend
+  syn match phpInnerHtmlPreProcAttrError contained "\w\+="he=e-1
+  syn match phpInnerHtmlPreProcAttrName contained "\(expr\|errmsg\|sizefmt\|timefmt\|var\|cgi\|cmd\|file\|virtual\|value\)="he=e-1
+
+  if !exists("html_no_rendering")
+    " rendering
+    syn cluster phpInnerHtmlTop contains=@Spell,phpInnerHtmlTag,phpInnerHtmlEndTag,phpInnerHtmlSpecialChar,phpInnerHtmlPreProc,phpInnerHtmlComment,phpInnerHtmlLink,javaScript,@phpInnerHtmlPreproc
+
+    syn region phpInnerHtmlStrike start="<del\>" end="</del\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlStrike start="<strike\>" end="</strike\_s*>"me=s-1 contains=@phpInnerHtmlTop
+
+    syn region phpInnerHtmlBold start="<b\>" end="</b\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlBoldUnderline,phpInnerHtmlBoldItalic
+    syn region phpInnerHtmlBold start="<strong\>" end="</strong\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlBoldUnderline,phpInnerHtmlBoldItalic
+    syn region phpInnerHtmlBoldUnderline contained start="<u\>" end="</u\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlBoldUnderlineItalic
+    syn region phpInnerHtmlBoldItalic contained start="<i\>" end="</i\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlBoldItalicUnderline
+    syn region phpInnerHtmlBoldItalic contained start="<em\>" end="</em\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlBoldItalicUnderline
+    syn region phpInnerHtmlBoldUnderlineItalic contained start="<i\>" end="</i\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlBoldUnderlineItalic contained start="<em\>" end="</em\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlBoldItalicUnderline contained start="<u\>" end="</u\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlBoldUnderlineItalic
+
+    syn region phpInnerHtmlUnderline start="<u\>" end="</u\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlUnderlineBold,phpInnerHtmlUnderlineItalic
+    syn region phpInnerHtmlUnderlineBold contained start="<b\>" end="</b\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlUnderlineBoldItalic
+    syn region phpInnerHtmlUnderlineBold contained start="<strong\>" end="</strong\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlUnderlineBoldItalic
+    syn region phpInnerHtmlUnderlineItalic contained start="<i\>" end="</i\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlUnderlineItalicBold
+    syn region phpInnerHtmlUnderlineItalic contained start="<em\>" end="</em\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlUnderlineItalicBold
+    syn region phpInnerHtmlUnderlineItalicBold contained start="<b\>" end="</b\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlUnderlineItalicBold contained start="<strong\>" end="</strong\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlUnderlineBoldItalic contained start="<i\>" end="</i\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlUnderlineBoldItalic contained start="<em\>" end="</em\_s*>"me=s-1 contains=@phpInnerHtmlTop
+
+    syn region phpInnerHtmlItalic start="<i\>" end="</i\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlItalicBold,phpInnerHtmlItalicUnderline
+    syn region phpInnerHtmlItalic start="<em\>" end="</em\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlItalicBold contained start="<b\>" end="</b\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlItalicBoldUnderline
+    syn region phpInnerHtmlItalicBold contained start="<strong\>" end="</strong\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlItalicBoldUnderline
+    syn region phpInnerHtmlItalicBoldUnderline contained start="<u\>" end="</u\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlItalicUnderline contained start="<u\>" end="</u\_s*>"me=s-1 contains=@phpInnerHtmlTop,phpInnerHtmlItalicUnderlineBold
+    syn region phpInnerHtmlItalicUnderlineBold contained start="<b\>" end="</b\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlItalicUnderlineBold contained start="<strong\>" end="</strong\_s*>"me=s-1 contains=@phpInnerHtmlTop
+
+    syn match phpInnerHtmlLeadingSpace "^\s\+" contained
+    syn region phpInnerHtmlLink start="<a\>\_[^>]*\<href\>" end="</a\_s*>"me=s-1 contains=@Spell,phpInnerHtmlTag,phpInnerHtmlEndTag,phpInnerHtmlSpecialChar,phpInnerHtmlPreProc,phpInnerHtmlComment,phpInnerHtmlLeadingSpace,phpInnerJavaScript,@phpInnerHtmlPreproc
+    syn region phpInnerHtmlH1 start="<h1\>" end="</h1\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlH2 start="<h2\>" end="</h2\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlH3 start="<h3\>" end="</h3\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlH4 start="<h4\>" end="</h4\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlH5 start="<h5\>" end="</h5\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlH6 start="<h6\>" end="</h6\_s*>"me=s-1 contains=@phpInnerHtmlTop
+    syn region phpInnerHtmlHead start="<head\>" end="</head\_s*>"me=s-1 end="<body\>"me=s-1 end="<h[1-6]\>"me=s-1 contains=phpInnerHtmlTag,phpInnerHtmlEndTag,phpInnerHtmlSpecialChar,phpInnerHtmlPreProc,phpInnerHtmlComment,phpInnerHtmlLink,phpInnerHtmlTitle,phpInnerJavaScript,phpInnerCssStyle,@phpInnerHtmlPreproc
+    syn region phpInnerHtmlTitle start="<title\>" end="</title\_s*>"me=s-1 contains=phpInnerHtmlTag,phpInnerHtmlEndTag,phpInnerHtmlSpecialChar,phpInnerHtmlPreProc,phpInnerHtmlComment,phpInnerJavaScript,@phpInnerHtmlPreproc
+  endif
+
+  if main_syntax != 'java' || exists("javascript")
+    " JAVA SCRIPT
+    " For example, $phpVar = '<img onload="foo()" />';
+    syn include @phpInnerHtmlJavaScript syntax/javascript.vim
+    unlet b:current_syntax
+    syn region  phpInnerHtmlScriptTag     contained start=+<script+ end=+>+ fold contains=phpInnerHtmlTagN,phpInnerHtmlString,phpInnerHtmlArg,phpInnerHtmlValue,phpInnerHtmlTagError,phpInnerHtmlEvent
+    hi def link phpInnerHtmlScriptTag phpInnerHtmlTag
+
+    " phpInnerHtml events (i.e. arguments that include phpInnerJavascript commands)
+    if exists("html_extended_events")
+      syn region phpInnerHtmlEvent        contained start=+\<on\a\+\s*=[\t ]*'+ end=+'+ contains=phpInnerHtmlEventSQ
+      syn region phpInnerHtmlEvent        contained start=+\<on\a\+\s*=[\t ]*"+ end=+"+ contains=phpInnerHtmlEventDQ
+    else
+      syn region phpInnerHtmlEvent        contained start=+\<on\a\+\s*=[\t ]*'+ end=+'+ keepend contains=phpInnerHtmlEventSQ
+      syn region phpInnerHtmlEvent        contained start=+\<on\a\+\s*=[\t ]*"+ end=+"+ keepend contains=phpInnerHtmlEventDQ
+    endif
+    syn region phpInnerHtmlEventSQ        contained start=+'+ms=s+1 end=+'+me=s-1 contains=@phpInnerHtmlJavaScript
+    syn region phpInnerHtmlEventDQ        contained start=+"+ms=s+1 end=+"+me=s-1 contains=@phpInnerHtmlJavaScript
+    hi def link phpInnerHtmlEventSQ phpInnerHtmlEvent
+    hi def link phpInnerHtmlEventDQ phpInnerHtmlEvent
+
+    " a phpInnerJavascript expression is used as an arg value
+    " syn region  phpInnerJavaScriptExpression contained start=+&{+ keepend end=+};+ contains=@phpInnerHtmlJavaScript,@phpInnerHtmlPreproc
+  endif
+
+  syn cluster phpInnerHtmlJavaScript      add=@phpInnerHtmlPreproc
+
+  " The default highlighting.
+  " NOTE: For now, this deliberately copies the definitions from html rather than link
+  " to the corresponding html tag name. If html is refactored to rename any 
+  " keywords then html highlighting would unexpectedly be cleared.
+  hi def link phpInnerHtmlTag                     Function
+  hi def link phpInnerHtmlEndTag                  Identifier
+  hi def link phpInnerHtmlArg                     Type
+  hi def link phpInnerHtmlValue                   String
+  hi def link phpInnerHtmlSpecialChar             Special
+
+  if !exists("html_no_rendering")
+    hi def link phpInnerHtmlH1                      Title
+    hi def link phpInnerHtmlH2                      phpInnerHtmlH1
+    hi def link phpInnerHtmlH3                      phpInnerHtmlH2
+    hi def link phpInnerHtmlH4                      phpInnerHtmlH3
+    hi def link phpInnerHtmlH5                      phpInnerHtmlH4
+    hi def link phpInnerHtmlH6                      phpInnerHtmlH5
+    hi def link phpInnerHtmlHead                    PreProc
+    hi def link phpInnerHtmlTitle                   Title
+    hi def link phpInnerHtmlBoldItalicUnderline     phpInnerHtmlBoldUnderlineItalic
+    hi def link phpInnerHtmlUnderlineBold           phpInnerHtmlBoldUnderline
+    hi def link phpInnerHtmlUnderlineItalicBold     phpInnerHtmlBoldUnderlineItalic
+    hi def link phpInnerHtmlUnderlineBoldItalic     phpInnerHtmlBoldUnderlineItalic
+    hi def link phpInnerHtmlItalicUnderline         phpInnerHtmlUnderlineItalic
+    hi def link phpInnerHtmlItalicBold              phpInnerHtmlBoldItalic
+    hi def link phpInnerHtmlItalicBoldUnderline     phpInnerHtmlBoldUnderlineItalic
+    hi def link phpInnerHtmlItalicUnderlineBold     phpInnerHtmlBoldUnderlineItalic
+    hi def link phpInnerHtmlLink                    Underlined
+    hi def link phpInnerHtmlLeadingSpace            None
+    if !exists("html_my_rendering")
+      hi def phpInnerHtmlBold                term=bold cterm=bold gui=bold
+      hi def phpInnerHtmlBoldUnderline       term=bold,underline cterm=bold,underline gui=bold,underline
+      hi def phpInnerHtmlBoldItalic          term=bold,italic cterm=bold,italic gui=bold,italic
+      hi def phpInnerHtmlBoldUnderlineItalic term=bold,italic,underline cterm=bold,italic,underline gui=bold,italic,underline
+      hi def phpInnerHtmlUnderline           term=underline cterm=underline gui=underline
+      hi def phpInnerHtmlUnderlineItalic     term=italic,underline cterm=italic,underline gui=italic,underline
+      hi def phpInnerHtmlItalic              term=italic cterm=italic gui=italic
+      if v:version > 800 || v:version == 800 && has("patch1038")
+          hi def phpInnerHtmlStrike              term=strikethrough cterm=strikethrough gui=strikethrough
+      else
+          hi def phpInnerHtmlStrike              term=underline cterm=underline gui=underline
+      endif
+    endif
+  endif
+
+  hi def link phpInnerHtmlPreStmt            PreProc
+  hi def link phpInnerHtmlPreError           Error
+  hi def link phpInnerHtmlPreProc            PreProc
+  hi def link phpInnerHtmlPreAttr            String
+  hi def link phpInnerHtmlPreProcAttrName    PreProc
+  hi def link phpInnerHtmlPreProcAttrError   Error
+  hi def link phpInnerHtmlString             String
+  hi def link phpInnerHtmlStatement          Statement
+  hi def link phpInnerHtmlComment            Comment
+  hi def link phpInnerHtmlCommentNested      phpInnerHtmlError
+  hi def link phpInnerHtmlCommentError       phpInnerHtmlError
+  hi def link phpInnerHtmlTagError           phpInnerHtmlError
+  hi def link phpInnerHtmlEvent              phpInnerJavaScript
+  hi def link phpInnerHtmlError              Error
+
+  hi def link phpInnerJavaScript             Special
+  hi def link phpInnerJavaScriptExpression   phpInnerJavaScript
+  hi def link phpInnerHtmlCssStyleComment    Comment
+  hi def link phpInnerHtmlCssDefinition      Special
+endif
+
+
 runtime! syntax/html.vim
 unlet b:current_syntax
 
@@ -79,6 +311,8 @@ if exists("php_parentError") && !exists("php_parent_error_open") && !exists("php
   let php_parent_error_open=1
 endif
 
+" End of copy of html syntax for embedding in php strings }}}
+
 syn cluster htmlPreproc add=phpRegion,phpRegionAsp,phpRegionSc
 
 syn include @sqlTop syntax/sql.vim
@@ -90,7 +324,11 @@ if exists( "php_sql_query")
 endif
 
 if exists( "php_htmlInStrings")
-  syn cluster phpAddStrings add=@htmlTop
+  if php_htmlInStrings==2
+    syn cluster phpAddStrings add=@phpInnerHtmlTop
+  else
+    syn cluster phpAddStrings add=@htmlTop
+  endif
 endif
 
 " make sure we can use \ at the beginning of the line to do a continuation
@@ -728,7 +966,6 @@ else
   hi def link phpIdentifier Identifier
   hi def link phpIdentifierSimply Identifier
 endif
-
 
 let b:current_syntax = "php"
 


### PR DESCRIPTION
This is pretty annoying when you're working with code that reads php
files or generates the contents of php files or generates snippets to
`eval()`.

When php_htmlInStrings was set to any value,
it would cause the html syntax rules to be embedded inside of the string
contents.

However, php.vim extends html.vim by allowing the php start tag to be
included, meaning that this is parsed as `<?php';`, i.e. the start of a
new string literal.

Work around that by using a different set of rules

The default behavior may be changed in the future for constants other
than 2 or 3

Fixes #12