### PR TITLE
Adds support to yield from

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -513,7 +513,7 @@ syn keyword phpRepeat as do endfor endforeach endwhile for foreach while contain
 syn keyword phpLabel case default switch contained
 
 " Statement
-syn keyword phpStatement return break continue exit goto yield contained
+syn keyword phpStatement return break continue exit goto yield from contained
 
 " Keyword
 syn keyword phpKeyword var const contained


### PR DESCRIPTION
This pull request adds support to missing `yield from` syntax. See https://www.php.net/manual/en/language.generators.syntax.php#control-structures.yield.from
